### PR TITLE
Add newline above .. code:: directive

### DIFF
--- a/main.hs
+++ b/main.hs
@@ -20,7 +20,7 @@ parseLines (('-':'>':cs):css) = (trim cs) : (listOf '-' (length cs)) : parseLine
 -- Subsection headings
 parseLines (('-':'-':'>':cs):css) = (trim cs) : (listOf '~' (length cs)) : parseLines css
 -- Code Sections
-parseLines (('#':'c':'o':'d':'e':cs):css) = (".. code:: " ++ (trim cs)) : 
+parseLines (('#':'c':'o':'d':'e':cs):css) = ("\n.. code:: " ++ (trim cs) ++ "\n") :
 						((map indent (takeWhile stopFunct css)) ++ 
 						(parseLines $ tail $ (dropWhile stopFunct css)))
 						where


### PR DESCRIPTION
RST doesn't recognize .. code:: or any other directive unless it is on a
new paragraph. This means you need to make sure there's a blank line
above where you generate it.

This fixes #1 by simply adding a newline above the generated code block.
In the future, it would be better to keep track of whether we're on a
new paragraph, so a newline isn't unnecessarily added.
